### PR TITLE
Fix non-object static component options and add externals

### DIFF
--- a/src/core.ts
+++ b/src/core.ts
@@ -142,8 +142,12 @@ function findSuper(proto: Object): VClass<Vue> {
 
 function collectOptions(cls: VClass<Vue>, keys: string[], optionsToWrite: ComponentOptions<Vue>) {
   let newOptions = keys.mapToObject(makeObject(cls));
-  for(let key of keys) {
-    optionsToWrite[key] = objAssign({}, newOptions[key], optionsToWrite[key])
+  for (let key of keys) {
+    if (typeof newOptions[key] === 'object') {
+      optionsToWrite[key] = objAssign({}, newOptions[key], optionsToWrite[key])
+    } else {
+      optionsToWrite[key] = newOptions[key];
+    }
   }
 }
 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -16,6 +16,8 @@ module.exports = {
   externals: {
     vue: 'vue',
     chai: 'chai',
+    vuex: 'vuex',
+    'reflect-metadata': 'reflect-metadata'
   },
   module: {
     rules: [


### PR DESCRIPTION
Firstly, thanks for this amazing library (even if you only meant to use it yourself, it's by far the best way to use Vue with Typescript).

The first commit allows a static property that is not an object to be properly fed to a component's options, for example:
```typescript
@Component
class Foo {
  static template = " ... "
}
```
The second commit adds vuex and reflect-metadata to webpack's externs so they are not included in the final build.